### PR TITLE
строка 9 - опциональный оператор стоял после типа

### DIFF
--- a/modules/20-functions/20-optional-parameters-in-callbacks/description.ru.yml
+++ b/modules/20-functions/20-optional-parameters-in-callbacks/description.ru.yml
@@ -6,7 +6,7 @@ theory: |
   Опциональные параметры в функциях задаются с помощью знака вопроса после типа:
 
   ```typescript
-  function split(str: string, separator: string?)
+  function split(str: string, separator?: string)
 
   split('hexlet');
   split('hexlet,code-basics', ',');


### PR DESCRIPTION
Исправил на   function split(str: string, separator?: string)