### PR TITLE
fix: correct misprint

### DIFF
--- a/modules/22-arrays/25-multi-dimensional-arrays/description.ru.yml
+++ b/modules/22-arrays/25-multi-dimensional-arrays/description.ru.yml
@@ -18,7 +18,7 @@ theory: |
   }
 
   // или так Array<User[]>
-  const users: User[] = [
+  const users: User[][] = [
     [{ name: 'Eva'}, { name: 'Adam' }],
   ];
   ```


### PR DESCRIPTION
Написано `User[]`, следует исправить на `User[][]`, так как именно это многомерный массив (аналог `Array<User[]>`).

В текущем виде ошибка: `Property 'name' is missing in type '[{ name: string; }, { name: string; }]' but required in type 'User'.`.