### PR TITLE
fix return values in the example

### DIFF
--- a/modules/10-basics/80-any/description.ru.yml
+++ b/modules/10-basics/80-any/description.ru.yml
@@ -73,9 +73,9 @@ instructions: |
 
   ```typescript
   getParams('per=10&page=5');
-  // { per: 10, page: 5 }
+  // { per: '10', page: '5' }
   getParams('name=hexlet&count=3&order=asc');
-  // { name: 'hexlet', count: 3, order: 'asc' }
+  // { name: 'hexlet', count: '3', order: 'asc' }
   ```
 
   Эту задачу лучше всего решать через метод `reduce()`


### PR DESCRIPTION
В примере показано, что числовые значения должны возвраться числами, но тесты проверяют на строки.