### PR TITLE
refact: Added some changes

### DIFF
--- a/modules/10-basics/55-objects/index.ts
+++ b/modules/10-basics/55-objects/index.ts
@@ -1,5 +1,5 @@
 // BEGIN
-function isComplete(course: { name: string, lessons: string[] }) {
+function isComplete(course: { name: string, lessons: string[] }): boolean {
   return course.lessons.length >= 4;
 }
 // END

--- a/modules/10-basics/90-modules/description.ru.yml
+++ b/modules/10-basics/90-modules/description.ru.yml
@@ -40,15 +40,15 @@ theory: |
   const helloWorld = Hello.helloWorld();
   ```
 
-  Больше всего этот механизм пригождается авторам библиотек и оберток с типами, они заключают все интерфейсы в один `namespace`, что упрощает пользователям слияние интерфейсов (тему одну одного из следующих уроков в курсе), а также гарантию отсутствия коллизий имен.
+  Больше всего этот механизм пригождается авторам библиотек и оберток с типами, они заключают все интерфейсы в один `namespace`, что упрощает пользователям слияние интерфейсов (тема одного из следующих уроков в курсе), а также гарантию отсутствия коллизий имен.
 
 instructions: |
   Реализуйте namespace `Company` в котором экспортируется функция `isEmployeeEmail()`. Функция принимает почту и домен. Если емейл пользователя содержит указанный домен, то функция возвращает `true`:
 
   ```typescript
-  Company.isEmployeeEmail({ email: 'tirion@hexlet.io', 'hexlet.io'});
+  Company.isEmployeeEmail('tirion@hexlet.io', 'hexlet.io');
   // true
-  Company.isEmployeeEmail({ email: 'user@example.com', 'hexlet.io'});
+  Company.isEmployeeEmail('user@example.com', 'hexlet.io');
   // false
   ```
 

--- a/modules/10-basics/90-modules/index.ts
+++ b/modules/10-basics/90-modules/index.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 // BEGIN
 namespace Company {
-  export function isEmployeeEmail(email: string, domain: string) {
-    return email.includes(domain);
+  export function isEmployeeEmail(email: string, domain: string): boolean {
+    return email.endsWith(`@${domain}`);
   }
 }
 // END

--- a/modules/10-basics/90-modules/test.ts
+++ b/modules/10-basics/90-modules/test.ts
@@ -2,6 +2,7 @@ import authorize from './index';
 
 test('function', () => {
   expect(authorize({ email: 'test@hexlet.io' })).toBe(true);
+  expect(authorize({ email: 'hexlet.io@example.com' })).toBe(false);
   expect(authorize({ email: 'test@example.com' })).toBe(false);
   expect(authorize(null)).toBe(false);
 });


### PR DESCRIPTION
1) В уроке "Именованные функции" [[4]](https://code-basics.com/ru/languages/typescript/lessons/named-functions) рекомендуется проставлять тип возвращаемого значения, но в данном решении учителя тип возвращаемого значения определяет TypeScript. Предлагаю указать его явно.
2) Исправлена опечатка в предложении, а также изменено решение учителя. Думаю, что предложенное мной решение более корректно.