### PR TITLE
Fix function overloads lesson

### DIFF
--- a/modules/20-functions/85-function-overloads/description.ru.yml
+++ b/modules/20-functions/85-function-overloads/description.ru.yml
@@ -9,9 +9,9 @@ theory: |
   function concat(a: number, b: number): string;
   function concat(a: string, b: string): string;
 
-  function concat(a: unknown, b: unknown): string {
+  function concat(a: any, b: any): string {
     if (typeof a === 'string') {
-      return `${a}{b}`;
+      return `${a}${b}`;
     } else {
       return `${a.toFixed()}${b.toFixed()}`;
     }
@@ -32,11 +32,11 @@ theory: |
 
   ```typescript
   function add(a: number, b: number, c: number): number;
-  function add(a: number, b: number): unknown;
-  function add(a: string, b: string): unknown;
+  function add(a: number, b: number): number;
+  function add(a: string, b: string): string;
 
   // Сигнатура подходит под все примеры выше
-  function add(a: unknown, b: unknown, c?: unknown): unknown {
+  function add(a: any, b: any, c?: number): unknown {
     // тут вся логика
     if (c === undefined) {
       // ...

--- a/modules/20-functions/90-type-narrowing/description.ru.yml
+++ b/modules/20-functions/90-type-narrowing/description.ru.yml
@@ -77,8 +77,8 @@ theory: |
   function concat(a: number, b: number): string;
   function concat(a: string, b: string): string;
 
-  function concat(a: unknown, b: unknown): string {
-    if (typeof a == 'string') {
+  function concat(a: any, b: any): string {
+    if (typeof a === 'string') {
       return `${a}${b}`;
       //        ^? (parameter) a: string
     } else {


### PR DESCRIPTION
При использовании типа `unknown` в примере typescript ругается
```
Property 'toFixed' does not exist on type 'unknown'.
```
Мне кажется, что можно вернуть тип `any` для перегрузки функции. Да и в доке typescript тоже есть примеры с `any` для перегрузки функции.
Аналогично поправил типы в другом примере.
Также поправил аналогичный пример из урока про `Narrowing`