### PR TITLE
Рефакторинг РУ

### DIFF
--- a/modules/22-arrays/20-type-annotations/index.ts
+++ b/modules/22-arrays/20-type-annotations/index.ts
@@ -1,6 +1,6 @@
 // BEGIN
 function compact(items: (number | null)[]): number[] {
-  return items.filter((item) => item !== null);
+  return items.filter((item) => item !== null) as number[];
 }
 // END
 

--- a/modules/22-arrays/20-type-annotations/index.ts
+++ b/modules/22-arrays/20-type-annotations/index.ts
@@ -1,5 +1,5 @@
 // BEGIN
-function compact(items: Array<number | null>): Array<number | null> {
+function compact(items: (number | null)[]): number[] {
   return items.filter((item) => item !== null);
 }
 // END


### PR DESCRIPTION
Исправлен тип возвращаемого из функции массива. Синтаксис описания массива изменен в соответствии с описанием урока – там написано, что предпочтение отдается короткому варианту, а `Array<Type>` используется для дженериков. 