### PR TITLE
fix: comment with returned fn value

### DIFF
--- a/modules/10-basics/40-named-functions/description.ru.yml
+++ b/modules/10-basics/40-named-functions/description.ru.yml
@@ -52,7 +52,7 @@ theory: |
     return `Hello, ${name.toUpperCase()}!`;
   }
 
-  getGreetingPhrase() // Hello, Guest!
+  getGreetingPhrase() // Hello, GUEST!
   ```
 
   ## Тип возвращаемого значения


### PR DESCRIPTION
Minor comment fix.
`name` should be in upper case