### PR TITLE
Add case for zero index

### DIFF
--- a/modules/25-types/20-union-types/test.ts
+++ b/modules/25-types/20-union-types/test.ts
@@ -1,17 +1,17 @@
 // import { assert } from 'type-assertions';
 // import type { Equal } from 'type-assertions';
 
-import lastIndex from "./index";
+import lastIndex from './index';
 
-test("lastIndex", () => {
+test('lastIndex', () => {
   // https://github.com/sindresorhus/is
   // https://github.com/unional/type-plus
   // https://github.com/colinhacks/zod
   // assert<Equal<ReturnType<typeof lastIndex>, number | null>>();
 
-  const str = "jest";
-  expect(lastIndex(str, "j")).toBe(0);
-  expect(lastIndex(str, "t")).toBe(3);
-  expect(lastIndex(str, "e")).toBe(1);
-  expect(lastIndex(str, "p")).toBeNull();
+  const str = 'jest';
+  expect(lastIndex(str, 'j')).toBe(0);
+  expect(lastIndex(str, 't')).toBe(3);
+  expect(lastIndex(str, 'e')).toBe(1);
+  expect(lastIndex(str, 'p')).toBeNull();
 });

--- a/modules/25-types/20-union-types/test.ts
+++ b/modules/25-types/20-union-types/test.ts
@@ -1,16 +1,17 @@
 // import { assert } from 'type-assertions';
 // import type { Equal } from 'type-assertions';
 
-import lastIndex from './index';
+import lastIndex from "./index";
 
-test('lastIndex', () => {
+test("lastIndex", () => {
   // https://github.com/sindresorhus/is
   // https://github.com/unional/type-plus
   // https://github.com/colinhacks/zod
   // assert<Equal<ReturnType<typeof lastIndex>, number | null>>();
 
-  const str = 'test';
-  expect(lastIndex(str, 't')).toBe(3);
-  expect(lastIndex(str, 'e')).toBe(1);
-  expect(lastIndex(str, 'p')).toBeNull();
+  const str = "jest";
+  expect(lastIndex(str, "j")).toBe(0);
+  expect(lastIndex(str, "t")).toBe(3);
+  expect(lastIndex(str, "e")).toBe(1);
+  expect(lastIndex(str, "p")).toBeNull();
 });


### PR DESCRIPTION
Решил задание с помощью тернарного оператора, зная что 0 приводится к false, если бы тест проверял в т.ч нулевой индекс, то моё решение бы не подошло.  Добавил проверку на элемент с индексом 0.