### PR TITLE
fix: add typecheck for 2nd fn argument

### DIFF
--- a/modules/20-functions/85-function-overloads/description.ru.yml
+++ b/modules/20-functions/85-function-overloads/description.ru.yml
@@ -9,7 +9,7 @@ theory: |
   function concat(a: string, b: string): string;
 
   function concat(a: unknown, b: unknown): string {
-    if (typeof a === 'number') {
+    if (typeof a === 'number' && typeof b === 'number') {
       return `${a.toFixed()}${b.toFixed()}`;
     }
 
@@ -34,7 +34,7 @@ theory: |
     (a: number, b: number): string;
     (a: string, b: string): string;
   } = (a: unknown, b: unknown) => {
-    if (typeof a === 'number') {
+    if (typeof a === 'number' && typeof b === 'number') {
       return `${a.toFixed()}${b.toFixed()}`;
     }
 


### PR DESCRIPTION
Add typecheck for 2nd function argument due to typescript error.
<img width="1418" alt="Screenshot 2023-01-13 at 17 02 08" src="https://user-images.githubusercontent.com/81411663/212316026-b365d1f6-83cd-4fc0-bc87-042a48eed8d6.png">
