### PR TITLE
fix: remove `.at()` method

### DIFF
--- a/modules/20-functions/90-type-narrowing/index.ts
+++ b/modules/20-functions/90-type-narrowing/index.ts
@@ -4,7 +4,7 @@ function last(value: string | number): string | number {
     return value % 10;
   }
 
-  return value.at(-1) ?? '';
+  return value[value.length - 1] ?? '';
 }
 // END
 


### PR DESCRIPTION
Отрефакторил эталонное решение из-за ошибки TS в онлайн редакторе.

<img width="1440" alt="Screenshot 2023-01-13 at 21 06 19" src="https://user-images.githubusercontent.com/81411663/212365647-96e28a72-9d00-4657-814c-102aff1b49cd.png">

Если возможно, необходимо сменить `target` в `.tsconfig` онлайн редактора на `ES2022 / ESNext`.

Я не знаю, как это сделать, поэтому просто переписал решение без метода `.at()`