### PR TITLE
fix description of object lesson

### DIFF
--- a/modules/10-basics/55-objects/description.ru.yml
+++ b/modules/10-basics/55-objects/description.ru.yml
@@ -61,7 +61,7 @@ instructions: |
 
   ```typescript
   // Определите тип исходя из структуры объекта
-  const course = {
+  const course1 = {
     name: 'Java',
     lessons: ['variables', 'functions', 'conditions'],
   };


### PR DESCRIPTION
A small typo. The constant "course" is created but "course1" is passed as an argument