### PR TITLE
feat: добавил ссылку на офиц документацию в 3 урок

### DIFF
--- a/modules/10-basics/30-variables/description.ru.yml
+++ b/modules/10-basics/30-variables/description.ru.yml
@@ -98,3 +98,5 @@ instructions: |
 tips:
   - |
     [Метод String.repeat()](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/String/repeat)
+  - |
+    [Официальная документация](https://www.typescriptlang.org/docs/handbook/2/basic-types.html)


### PR DESCRIPTION
Написал просто "официальная документация", так как в уроке про массивы написано также. Не стал уточнять, что-де ссылка на раздел доки про типы.