### PR TITLE
to compose v2 and fix linter warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,17 @@
 compose-setup: compose-build compose-install
 
 compose:
-	docker-compose up
+	docker compose up
 
 compose-build:
-	docker-compose pull
-	docker-compose build
+	docker compose pull
+	docker compose build
 
 compose-install:
-	docker-compose run exercises npm install
+	docker compose run exercises npm install
 
 compose-update:
-	docker-compose run exercises npx ncu -u
+	docker compose run exercises npx ncu -u
 
 code-lint:
 	npx eslint .
@@ -25,20 +25,20 @@ code-lint:
 #   @$$(find . -type f -name *.class -delete)
 
 compose-bash:
-	docker-compose run exercises bash
+	docker compose run exercises bash
 
 compose-test:
-	docker-compose run exercises make test
+	docker compose run exercises make test
 
 compose-description-lint:
-	docker-compose run exercises make description-lint
+	docker compose run exercises make description-lint
 
 compose-schema-validate:
-	docker-compose run exercises make schema-validate
+	docker compose run exercises make schema-validate
 
 ci-check:
-	docker-compose --file docker-compose.yml build
-	docker-compose --file docker-compose.yml up --abort-on-container-exit
+	docker compose --file docker-compose.yml build
+	docker compose --file docker-compose.yml up --abort-on-container-exit
 
 test-fast:
 	npx jest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 * Discuss the project on Telegram: https://t.me/hexletcommunity/12
 
+### Requirements
+
+* docker
+* docker compose V2
+* make
+
 ## Develop
 
 ```bash

--- a/modules/35-interfaces/10-interfaces-overview/test.ts
+++ b/modules/35-interfaces/10-interfaces-overview/test.ts
@@ -1,5 +1,3 @@
-import * as ta from 'type-assertions';
-
 import Car from './index';
 
 test('Car', () => {

--- a/modules/35-interfaces/20-interface-using/test.ts
+++ b/modules/35-interfaces/20-interface-using/test.ts
@@ -1,5 +1,3 @@
-import * as ta from 'type-assertions';
-
 import superMan from './index';
 
 test('guess who', () => {


### PR DESCRIPTION
Смена команды docker-compose на docker compose в связи с https://docs.docker.com/compose/migrate/. С docker-compose проект не устанавливается и не запускается. Удалил две лишние, по мнению линтера, строки. Но есть еще один варнинг в решении учителя `/exercises-typescript/modules/40-generics/60-generic-classes/index.ts
  13:12  warning  Forbidden non-null assertion`