### PR TITLE
change solution class-as-types 

### DIFF
--- a/modules/30-classes/15-class-as-types/index.ts
+++ b/modules/30-classes/15-class-as-types/index.ts
@@ -1,22 +1,24 @@
 // BEGIN
+type OpitonName = string;
+type OpitonSize = number;
+type FileOptions = { name: OpitonName, size: OpitonSize };
+
 class File {
-  name: string;
+  name: OpitonName;
 
-  size: number;
+  size: OpitonSize;
 
-  isCopy?: boolean;
+  private isCopy: boolean;
 
-  constructor(options: File) {
+  constructor(options: FileOptions) {
     this.name = options.name;
     this.size = options.size;
-
-    if (options instanceof File) {
-      this.isCopy = true;
-    }
+    this.isCopy = (options instanceof File);
   }
 
-  toString() {
-    return [this.isCopy && '(copy)', this.name, `(${this.size} bytes)`].filter(Boolean).join(' ');
+  toString(): string {
+    const copyString = this.isCopy ? '(copy) ' : '';
+    return `${copyString}${this.name} (${this.size} bytes)`;
   }
 }
 // END


### PR DESCRIPTION
В решении учителя несколько проблем:

1. Усложнённое решение
2. Нарушен принцип сокрытия реализации

Так как isCopy - это служебное поле для внутренней логики класса, оно не должно быть видно снаружи пользователям этого класса. Иначе можно сделать так: `new File({ name: ‘’ size: 0, **isCopy: true** })` — на функциональности это не скажется, но isCopy висит в подсказках редактора. А мы типизируем всё, чтобы редактор не подсказывал фигню.

Поэтому на входящие параметры должен быть тип или интерфейс на весь класс, а `isCopy` остаётся чисто приватным методом и используется только внутри, пользователь его не передаёт.