### PR TITLE
[#239] add missed const definition "currentHour" in the lesson task

### DIFF
--- a/modules/30-classes/80-abstract-classes/description.ru.yml
+++ b/modules/30-classes/80-abstract-classes/description.ru.yml
@@ -60,6 +60,7 @@ instructions: |
   // 24-часовой формат
   class Clock24 extends Clock {
     render(): string {
+      const currentHour = this.hours % 24;
       const hours = currentHour.toString().padStart(2, '0');
       const minutes = this.minutes.toString().padStart(2, '0');
 


### PR DESCRIPTION
Constante definition "currentHour" for Clock24 class was missed in the task of "Abstract classes" lesson. This PR adds it