### PR TITLE
[#241] remove whitespace in function parameters brackets

### DIFF
--- a/modules/35-interfaces/30-interface-implementation/description.ru.yml
+++ b/modules/35-interfaces/30-interface-implementation/description.ru.yml
@@ -73,8 +73,8 @@ theory: |
 
   ```typescript
   interface ICalculate {
-    sum: (num1: number, num2: number ) => number;
-    multiply? : (num1: number, num2: number ) => number;
+    sum: (num1: number, num2: number) => number;
+    multiply? : (num1: number, num2: number) => number;
   }
 
   class Summator implements ICalculate {


### PR DESCRIPTION
There was 2 odd whitespaces in function parameters brackets at the example in interface implementation lesson