### PR TITLE
update

### DIFF
--- a/modules/25-types/70-variability/index.ts
+++ b/modules/25-types/70-variability/index.ts
@@ -1,7 +1,5 @@
 // BEGIN
-type Transaction = {
-  apply: (amount: number) => number;
-};
+type Transaction = { apply: (amount: number) => number } | { apply: () => never };
 
 type Wallet = {
   transactions: Transaction[];

--- a/modules/25-types/70-variability/test.ts
+++ b/modules/25-types/70-variability/test.ts
@@ -39,5 +39,5 @@ test('applyTransactions', () => {
 
   expect(applyTransactions(wallet2)).toBe(10);
 
-  ta.assert<ta.Equal<Parameters<Transaction['apply']>, [number]>>();
+  ta.assert<ta.Equal<Parameters<Transaction['apply']>, [number] | []>>();
 });


### PR DESCRIPTION
Как будто бы можно "дотипизировать" `Transation`, если в тестах есть такой вызов:
```js
const wallet2: Wallet = {
    balance: 10,
    transactions: [
      ...,
      {
        apply: () => {
          throw new Error('Error');
        },
      },
      ...,
    ],
  };

  expect(applyTransactions(wallet2)).toBe(10);
```