### PR TITLE
Fix: Map.set() fn has to return Map instance in order to chain operations. 

### DIFF
--- a/modules/40-generics/40-many-parameters/index.ts
+++ b/modules/40-generics/40-many-parameters/index.ts
@@ -1,7 +1,7 @@
 // BEGIN
 type MyMap<K, V> = {
   values: Map<K, V>;
-  set(key: K, value: V): void;
+  set(key: K, value: V): Map<K, V>;
   get(key: K): V | undefined;
 };
 // END

--- a/modules/40-generics/40-many-parameters/test.ts
+++ b/modules/40-generics/40-many-parameters/test.ts
@@ -1,23 +1,26 @@
-import * as ta from 'type-assertions';
+import * as ta from "type-assertions";
 
-import MyMap from './index';
+import MyMap from "./index";
 
-test('MyMap', () => {
+test("MyMap", () => {
   const map: MyMap<string, number> = {
     values: new Map(),
     set(key, value) {
       this.values.set(key, value);
+      return this;
     },
     get(key) {
       return this.values.get(key);
     },
   };
 
-  map.set('one', 1);
-  map.set('two', 2);
+  map.set("one", 1);
+  map.set("two", 2);
 
-  expect(map.get('one')).toBe(1);
-  expect(map.get('two')).toBe(2);
+  expect(map.get("one")).toBe(1);
+  expect(map.get("two")).toBe(2);
 
-  ta.assert<ta.Equal<Parameters<MyMap<string, string>['set']>, [string, string]>>();
+  ta.assert<
+    ta.Equal<Parameters<MyMap<string, string>["set"]>, [string, string]>
+  >();
 });

--- a/modules/40-generics/40-many-parameters/test.ts
+++ b/modules/40-generics/40-many-parameters/test.ts
@@ -1,26 +1,26 @@
-import * as ta from "type-assertions";
+import * as ta from 'type-assertions';
 
-import MyMap from "./index";
+import MyMap from './index';
 
-test("MyMap", () => {
+test('MyMap', () => {
   const map: MyMap<string, number> = {
     values: new Map(),
     set(key, value) {
       this.values.set(key, value);
-      return this;
+      return this.values;
     },
     get(key) {
       return this.values.get(key);
     },
   };
 
-  map.set("one", 1);
-  map.set("two", 2);
+  map.set('one', 1);
+  map.set('two', 2);
 
-  expect(map.get("one")).toBe(1);
-  expect(map.get("two")).toBe(2);
+  expect(map.get('one')).toBe(1);
+  expect(map.get('two')).toBe(2);
 
   ta.assert<
-    ta.Equal<Parameters<MyMap<string, string>["set"]>, [string, string]>
+    ta.Equal<Parameters<MyMap<string, string>['set']>, [string, string]>
   >();
 });


### PR DESCRIPTION
As per MDN: [Since the set() method returns back the same Map object, you can chain the method calls](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set#using_the_set_with_chaining)

Fixed tests & teachers solution.