### PR TITLE
Explicit check for empty arrays before using Array.every()

### DIFF
--- a/modules/22-arrays/50-tuples/index.ts
+++ b/modules/22-arrays/50-tuples/index.ts
@@ -2,6 +2,10 @@
 export type Point = [number, number, number];
 
 function isTheSamePoint(p1: Point, p2: Point): boolean {
+  if (p1.length !== p2.length) {
+    return false;
+  }
+  
   return p1.every((el, i) => el === p2[i]);
 }
 // END


### PR DESCRIPTION
This change adds an explicit check for empty arrays before using Array.every().
Reason:
In JS/TS, Array.prototype.every() returns true for empty arrays.
Fix helps for scenarios like: 
const a = [];
const b = [1, 2, 3];