### PR TITLE
Fix class-as-types example and closing code fences

### DIFF
--- a/modules/10-basics/70-type-aliases/en/README.md
+++ b/modules/10-basics/70-type-aliases/en/README.md
@@ -5,7 +5,7 @@ Let's imagine a program that has a user object. This object is used everywhere. 
 function doSomething(user: { firstName: string, lastName: number }) {}
 function doSomethingElse(user: { firstName: string, lastName: number }) {}
 function doSomethingAnother(user: { firstName: string, lastName: number }) {}
-````
+```
 
 First, there is a lot of duplication. Secondly, it is much more difficult to change the structure, because you will have to edit all the places where this definition appears. In this lesson, let's learn how to avoid such problems.
 

--- a/modules/10-basics/70-type-aliases/ru/README.md
+++ b/modules/10-basics/70-type-aliases/ru/README.md
@@ -5,7 +5,7 @@
 function doSomething(user: { firstName: string, pointsCount: number }) {}
 function doSomethingElse(user: { firstName: string, pointsCount: number }) {}
 function doSomethingAnother(user: { firstName: string, pointsCount: number }) {}
-````
+```
 
 Во-первых, здесь много дублирования. Во-вторых, значительно усложняется изменение структуры, так как придется руками править все места, где встречается это определение. В этом уроке разберем, как избежать таких проблем.
 

--- a/modules/25-types/50-type-hierarcy/en/README.md
+++ b/modules/25-types/50-type-hierarcy/en/README.md
@@ -65,7 +65,7 @@ Another important property is that when we combine any type with `unknown` we al
 
 ```typescript
 type UnionWithUnknown = unknown | number | boolean;
-````
+```
 
 This behavior is explained by the fact that `unknown` is a superset of all types, so any union with it gives it itself. The exception here is `any`, which even in this case disables type checking and does not obey the model of types as sets.
 

--- a/modules/25-types/50-type-hierarcy/ru/README.md
+++ b/modules/25-types/50-type-hierarcy/ru/README.md
@@ -65,7 +65,7 @@ unknownValue.toUpperCase(); // Error: Property 'toUpperCase' does not exist on t
 
 ```typescript
 type UnionWithUnknown = unknown | number | boolean;
-````
+```
 
 Такое поведение объясняется тем, что `unknown` — это надмножество всех типов, поэтому любое объединение с ним дает его само. Исключением тут является `any`, который и в этом случае отключает проверку типов и не подчиняется модели типов как множеств.
 

--- a/modules/30-classes/15-class-as-types/en/README.md
+++ b/modules/30-classes/15-class-as-types/en/README.md
@@ -48,6 +48,6 @@ class Point {
 }
 
 const point = new Point(1, 2);
-point.isEqual(new Point(10, 1)); // OK
+point.isEqual(new Point(1, 2)); // OK
 point.isEqual({ x: 1, y: 2}); // Error: Argument of type '{ x: number; y: number; }' is not assignable to parameter of type 'Point'.
 ````

--- a/modules/30-classes/15-class-as-types/en/README.md
+++ b/modules/30-classes/15-class-as-types/en/README.md
@@ -50,4 +50,4 @@ class Point {
 const point = new Point(1, 2);
 point.isEqual(new Point(1, 2)); // OK
 point.isEqual({ x: 1, y: 2}); // Error: Argument of type '{ x: number; y: number; }' is not assignable to parameter of type 'Point'.
-````
+```

--- a/modules/30-classes/15-class-as-types/ru/README.md
+++ b/modules/30-classes/15-class-as-types/ru/README.md
@@ -50,6 +50,6 @@ class Point {
 const point = new Point(1, 2);
 point.isEqual(new Point(1, 2)); // OK
 point.isEqual({ x: 1, y: 2}); // Error: Argument of type '{ x: number; y: number; }' is not assignable to parameter of type 'Point'.
-````
+```
 
 <!-- TODO - автору: не хватает описания кода - на что обратить внимание, или что тут сделали -->

--- a/modules/30-classes/15-class-as-types/ru/README.md
+++ b/modules/30-classes/15-class-as-types/ru/README.md
@@ -48,7 +48,7 @@ class Point {
 }
 
 const point = new Point(1, 2);
-point.isEqual(new Point(10, 1)); // OK
+point.isEqual(new Point(1, 2)); // OK
 point.isEqual({ x: 1, y: 2}); // Error: Argument of type '{ x: number; y: number; }' is not assignable to parameter of type 'Point'.
 ````
 


### PR DESCRIPTION
## Что и почему

Правки пришли из обратной связи по зеркальному курсу Хекслета («Продвинутый TypeScript», урок «Классы как типы»): в примере создавалась точка `(1, 2)` и сравнивалась с `(10, 1)`.

### 1. Пример в `30-classes/15-class-as-types` (ru + en)

```diff
 const point = new Point(1, 2);
-point.isEqual(new Point(10, 1)); // OK
+point.isEqual(new Point(1, 2)); // OK
```

Комментарий `// OK` про то, что вызов проходит проверку типов (в контрасте со следующей строкой `// Error: …`), так что формально он был верен. Но разные точки рядом с `// OK` читаются как «ожидали совпадения и получили его», хотя урок вообще не про результат сравнения. Теперь аргументы совпадают с получателем, и пример показывает ровно то, о чём урок: класс с приватными полями требует настоящий экземпляр.

### 2. Закрывающие code fence — 4 бэктика вместо 3 (6 файлов)

- `30-classes/15-class-as-types/{ru,en}/README.md`
- `25-types/50-type-hierarcy/{ru,en}/README.md`
- `10-basics/70-type-aliases/{ru,en}/README.md`

Рендерится корректно (CommonMark принимает закрывающий fence не короче открывающего), но лишний символ — опечатка, и он попадает в буфер при копировании блока.

Отдельным коммитом, чтобы содержательная правка примера не утонула в механической чистке.

## Проверка

- `grep -rn '^\`\`\`\`$' modules` — пусто.
- `rumdl check --config ../base-image/common/.rumdl.toml` по затронутым урокам — вывод байт-в-байт совпадает с `origin/main` (2 предсуществующих `MD047` в `10-basics/70-type-aliases/en/`, в диф не брал).
- `index.ts` / `test.ts` уроков не затронуты — правка только в README.