### PR TITLE
Fix intersection illustration in the structural-typing lesson

### DIFF
--- a/modules/25-types/60-structural-typing/en/README.md
+++ b/modules/25-types/60-structural-typing/en/README.md
@@ -118,7 +118,7 @@ const user: UnionUser = { username: 'test', type: 'user' } // a match with one o
 
 The resulting type `IntersectionUser` describes objects that contain the fields `username`, `password` and `type`. And `UnionUser` type describes objects that contain `username` and `password` **OR** `type` fields.
 
-![object intersection](https://raw.githubusercontent.com/hexlet-basics/exercises-typescript/main/modules/25-types/60-structural-typing/assets/structual_object.png)
+![object intersection](https://raw.githubusercontent.com/hexlet-basics/exercises-typescript/main/modules/25-types/60-structural-typing/assets/object_intersection.png)
 
 In set algebra, the intersection of two sets is also called logical multiplication. For types, the term 'product type' is used. The union of sets is also called logical addition, and for types, the 'tagged union'.
 

--- a/modules/25-types/60-structural-typing/ru/README.md
+++ b/modules/25-types/60-structural-typing/ru/README.md
@@ -118,7 +118,7 @@ const user: UnionUser = { username: 'test', type: 'user' } // достаточн
 
 Получившийся тип `IntersectionUser` описывает объекты, которые содержат поля `username`, `password` и `type`. А тип `UnionUser` — объекты, которые содержат поля `username` и `password` **ИЛИ** `type`.
 
-![object intersection](../assets/structual_object.png)
+![object intersection](../assets/object_intersection.png)
 
 В алгебре множеств пересечение двух множеств также называют логическим умножением. А для типов используют термин произведение типов. Объединение множеств же называют логическим сложением, а для типов — сумма типов.
 


### PR DESCRIPTION
Вторая иллюстрация урока «Структурная типизация» ссылалась на `structual_object.png` — картинку от первого примера (поля `firstName`/`lastName`), хотя пример рядом с ней про `IntersectionUser` с полями `username`/`password` и `type`. Рядом в `assets/` лежала неиспользуемая `object_intersection.png`, на которой изображены ровно эти два множества и их пересечение `admin` — на неё и переключил ссылку в ru- и en-локали.

Теперь оба ассета урока используются, ни один не остаётся сиротой. Стиль ссылок сохранён: в ru относительный путь, в en абсолютный URL.

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)