### PR TITLE
Fix generic constraint example in the generic-types lesson

### DIFF
--- a/modules/40-generics/20-generic-types/en/README.md
+++ b/modules/40-generics/20-generic-types/en/README.md
@@ -63,7 +63,7 @@ interface HasId {
   id: number;
 }
 
-type MyColl<T extends HasId | number> = {
+type MyColl<T extends HasId> = {
   data: Array<T>;
   forEach(callback: (value: T, index: number, array: Array<T>) => void): void;
   at(index: number): T | undefined;
@@ -73,6 +73,7 @@ type MyColl<T extends HasId | number> = {
 This allows us to use the `MyColl` type only with types that implement the `HasId` interface. For example, such code will not work:
 
 ```typescript
+// Error: Type 'number' does not satisfy the constraint 'HasId'.
 const coll: MyColl<number> = {
   data: [1, 3, 8],
   forEach(callback) {

--- a/modules/40-generics/20-generic-types/ru/README.md
+++ b/modules/40-generics/20-generic-types/ru/README.md
@@ -65,7 +65,7 @@ interface HasId {
   id: number;
 }
 
-type MyColl<T extends HasId | number> = {
+type MyColl<T extends HasId> = {
   data: Array<T>;
   forEach(callback: (value: T, index: number, array: Array<T>) => void): void;
   at(index: number): T | undefined;
@@ -75,6 +75,7 @@ type MyColl<T extends HasId | number> = {
 Это позволяет нам использовать тип `MyColl` только с типами, которые реализуют интерфейс `HasId`. Например, такой код не будет работать:
 
 ```typescript
+// Error: Type 'number' does not satisfy the constraint 'HasId'.
 const coll: MyColl<number> = {
   data: [1, 3, 8],
   forEach(callback) {


### PR DESCRIPTION
В разделе «Ограничения дженериков» текст обещает, что `MyColl` работает только с типами, реализующими `HasId`, а ограничение было записано как `T extends HasId | number`. Из-за этого следующий пример, подписанный «такой код не будет работать», прекрасно компилировался — именно на это указывал репортёр в #296.

Сузил ограничение до `T extends HasId` в ru- и en-локали и добавил в пример текст ошибки компилятора.

Проверено через `tsc --noEmit --strict`:

- `MyColl<number>` → `error TS2344: Type 'number' does not satisfy the constraint 'HasId'.` (ровно та формулировка, что добавлена в комментарий);
- `MyColl<User>`, где у `User` есть `id: number` → компилируется без ошибок.

Fixes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)