### PR TITLE
clarify the filter() return type in the generic-functions exercise

### DIFF
--- a/modules/40-generics/30-generic-functions/en/EXERCISE.md
+++ b/modules/40-generics/30-generic-functions/en/EXERCISE.md
@@ -11,4 +11,6 @@ const newColl = coll.filter((value) => value % 2 == 0);
 console.log(newColl.items); // [10]
 ```
 
-The type includes two methods: [push()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) and [filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), matching the signature of Array methods. The data inside should be stored in the `items` property. For `push()`, accept the convention that the method takes only one parameter. Ignore the other parameters.
+The type includes two methods: [push()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) and [filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter). `push()` takes a value of the same type as the collection elements — unlike the `Array` method, accept the convention that there is only one parameter. `filter()` takes a callback with the same parameters as the method of the same name in `Array`: `value`, `index`, and `array`. The data inside should be stored in the `items` property.
+
+The return values, however, do not match completely. `push()`, just like in `Array`, returns the new length of the collection. But `filter()` returns not an array — it returns a new collection of the `MyArray<T>` type. That is why the result of filtering in the example above has the `items` property.

--- a/modules/40-generics/30-generic-functions/ru/EXERCISE.md
+++ b/modules/40-generics/30-generic-functions/ru/EXERCISE.md
@@ -11,4 +11,6 @@ const newColl = coll.filter((value) => value % 2 == 0);
 console.log(newColl.items); // [10]
 ```
 
-Тип включает в себя два метода: [push()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) и [filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), совпадающие по сигнатуре с методами Array. Данные внутри должны храниться в свойстве `items`. Для `push()` примем соглашение, что метод принимает только один параметр. Игнорируйте остальные параметры.
+Тип включает в себя два метода: [push()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) и [filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter). `push()` принимает значение того же типа, что и элементы коллекции — в отличие от метода `Array`, примем соглашение, что параметр только один. `filter()` принимает колбек с такими же параметрами, как у одноименного метода `Array`: `value`, `index` и `array`. Данные внутри должны храниться в свойстве `items`.
+
+А вот возвращаемые значения совпадают не полностью. `push()`, как и в `Array`, возвращает новую длину коллекции. `filter()` же возвращает не массив, а новую коллекцию типа `MyArray<T>` — поэтому в примере выше у результата фильтрации есть свойство `items`.


### PR DESCRIPTION
Closes #269

Задание урока «Дженерики (Функции)» говорило, что `push()` и `filter()` «совпадают по сигнатуре с методами Array». Но `filter()` обязан возвращать `MyArray<T>`, а не `T[]`: иначе `newColl.items` из примера в этом же задании не типизируется. Из-за этого студент решил, что решение учителя ошибочно.

Теперь текст разделяет, что совпадает (параметры колбэка), а что отличается (тип возврата). `index.ts` и `test.ts` не менялись.

🤖 Generated with [Claude Code](https://claude.com/claude-code)