### PR TITLE
fix the function overloading claim in the type-narrowing theory

### DIFF
--- a/modules/20-functions/90-type-narrowing/en/README.md
+++ b/modules/20-functions/90-type-narrowing/en/README.md
@@ -79,20 +79,23 @@ function foo(value: number | string) {
 
 Within each `case` block, the type of the value is narrowed down to what was in the `case` itself.
 
-Function overloading in TypeScript is also an example of how type narrowing works:
+Type narrowing is also needed for function overloading. It is important to understand that overloading itself does not narrow types: overload signatures describe how the function can be called from the outside, but inside the implementation the parameters stay wide. That is why the function body needs type guards:
 
 ```typescript
 function concat(a: number, b: number): string;
 function concat(a: string, b: string): string;
 
-function concat(a: any, b: any): string {
-  if (typeof a === 'string') {
-    return `${a}${b}`; // (parameter) a: string
-  } else {
+function concat(a: unknown, b: unknown): string {
+  if (typeof a === 'number' && typeof b === 'number') {
+    // here a and b are narrowed down to number
     return `${a.toFixed()}${b.toFixed()}`;
   }
+
+  return `${a}${b}`;
 }
 ```
+
+The compiler does not transfer types from the overload signatures into the function body. Even if all overloads describe the same parameter types, inside the implementation we get the wide type and have to narrow it ourselves.
 
 ## Type Guard
 

--- a/modules/20-functions/90-type-narrowing/ru/README.md
+++ b/modules/20-functions/90-type-narrowing/ru/README.md
@@ -79,20 +79,23 @@ function foo(value: number | string) {
 
 Внутри каждого блока `case` тип значения сужается до того, что было в самом `case`.
 
-Перегрузка функций в TypeScript — это тоже пример работы сужения типов:
+Сужение типа нужно и при перегрузке функций. Важно понимать, что сама перегрузка типы не сужает: сигнатуры перегрузок описывают, как функцию можно вызвать снаружи, но внутри реализации параметры остаются широкими. Поэтому в теле функции нужны защитники типа:
 
 ```typescript
 function concat(a: number, b: number): string;
 function concat(a: string, b: string): string;
 
-function concat(a: any, b: any): string {
-  if (typeof a === 'string') {
-    return `${a}${b}`; // (parameter) a: string
-  } else {
+function concat(a: unknown, b: unknown): string {
+  if (typeof a === 'number' && typeof b === 'number') {
+    // здесь a и b сужены до number
     return `${a.toFixed()}${b.toFixed()}`;
   }
+
+  return `${a}${b}`;
 }
 ```
+
+Компилятор не переносит типы из сигнатур перегрузок в тело функции. Даже если все перегрузки описывают одинаковые типы параметров, внутри реализации мы получим широкий тип и сузить его придётся самостоятельно.
 
 ## Защитники типа (Type Guard)
 


### PR DESCRIPTION
Closes #355

Репорт от студента: в теории урока «Сужение типа (Narrowing)» утверждалось, что перегрузка функций — пример работы сужения типов. Это неверно.

## Что не так

Перегрузка сама по себе типы не сужает: компилятор не переносит типы из сигнатур перегрузок в тело реализации. Старый пример проходил проверку только за счёт `any` и ломался, как только `any` заменяли на `unknown`.

Проверено на `tsc 5.8.3 --strict`:

| Проверка | Результат |
| --- | --- |
| старый пример как есть (`any`) | компилируется |
| то же, но `any` → `unknown` | `TS18046: 'a' is of type 'unknown'` в ветке `else` |
| перегрузки + реализация `(a: string \| number, …)`, без `typeof` | `TS2339: Property 'toFixed' does not exist on type 'string \| number'` |

Третья проверка решающая: даже когда все сигнатуры перегрузок описывают одинаковые типы параметров, тело реализации видит полный union без какого-либо сужения. Всё сужение в примере давал `typeof`, а не перегрузка.

## Что сделано

Тезис переформулирован на противоположный: перегрузка не сужает типы, и именно поэтому внутри реализации нужны защитники типа. Пример выровнен с предыдущим уроком `85-function-overloads`, где то же самое уже написано корректно — с `unknown` и проверкой `number`-first.

Правки в `ru` и `en` (локали `es` у курса нет). Код упражнения не менялся.

## Проверка

- сниппет, извлечённый скриптом прямо из отредактированных `ru/README.md` и `en/README.md`, компилируется: `tsc --strict --noEmit` → `exit=0`
- `rumdl check` (конфиг из `base-image/common/.rumdl.toml`, цель `markdown-lint`) → `No issues found in 2 files`

Кстати, ошибка прошла CI потому, что проверка типов в CI не включена — #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
