### PR TITLE
fix the claim that static members cannot be overridden

### DIFF
--- a/modules/30-classes/70-static-property/en/README.md
+++ b/modules/30-classes/70-static-property/en/README.md
@@ -25,7 +25,7 @@ CustomFile.isCustomFile(new CustomFile('open-world.jpeg', 1000)); // true
 
 Static methods and properties can also be assigned the `public`, `protected` and `private` access modifiers and the `readonly` immutability modifier. This allows you to restrict the use of properties and methods to the current class or descendants only.
 
-Unlike JavaScript, in TypeScript static properties and methods cannot be overridden in subclasses:
+Static properties and methods are inherited, and a subclass can override them — just like in JavaScript:
 
 ```typescript
 class CustomFile {
@@ -37,17 +37,35 @@ class CustomFile {
 }
 
 class ImageCustomFile extends CustomFile {
-  static maxCustomFileSize = 2000; // Error!
+  static maxCustomFileSize = 2000;
 
-  static isCustomFile(file: CustomFile): boolean { // Error!
+  static isCustomFile(file: CustomFile): boolean {
     return file instanceof ImageCustomFile;
   }
 }
+
+const file = new ImageCustomFile();
+
+console.log(ImageCustomFile.maxCustomFileSize); // 2000
+console.log(ImageCustomFile.isCustomFile(file)); // true
 ```
-Such code cannot be compiled. The access to static properties and methods of the parent class remains:
+
+Here `ImageCustomFile` declared its own `maxCustomFileSize` and `isCustomFile`, and accessing them through the subclass name gives exactly those.
+
+TypeScript adds one requirement on top: the type of an overridden property or method has to stay compatible with the parent one. Replace the number with a string and the code will not compile:
 
 ```typescript
-const file = new ImageCustomFile();
-console.log(ImageCustomFile.maxCustomFileSize); // 1000
-console.log(ImageCustomFile.isCustomFile(file)); // true
+class TextCustomFile extends CustomFile {
+  static maxCustomFileSize = 'unlimited'; // Error!
+}
+```
+
+The compiler says `Class static side 'typeof TextCustomFile' incorrectly extends base class static side 'typeof CustomFile'`: the static side of the subclass no longer fits the static side of the parent.
+
+A subclass that overrides nothing uses the static properties and methods of its parent:
+
+```typescript
+class VideoCustomFile extends CustomFile {}
+
+console.log(VideoCustomFile.maxCustomFileSize); // 1000
 ```

--- a/modules/30-classes/70-static-property/ru/README.md
+++ b/modules/30-classes/70-static-property/ru/README.md
@@ -27,7 +27,7 @@ CustomFile.isCustomFile(new CustomFile('open-world.jpeg', 1000)); // true
 
 Статическим методам и свойствам также можно назначить модификаторы доступа `public`, `protected` и `private` и модификатор неизменяемости `readonly`. Это позволяет ограничить использование свойств и методов только текущим классом или наследниками.
 
-В отличие от JavaScript в TypeScript статические свойства и методы не могут быть переопределены в подклассах:
+Статические свойства и методы наследуются, и подкласс может их переопределить — так же, как в JavaScript:
 
 ```typescript
 class CustomFile {
@@ -39,22 +39,35 @@ class CustomFile {
 }
 
 class ImageCustomFile extends CustomFile {
-  static maxCustomFileSize = 2000; // Error!
+  static maxCustomFileSize = 2000;
 
-  static isCustomFile(file: CustomFile): boolean { // Error!
+  static isCustomFile(file: CustomFile): boolean {
     return file instanceof ImageCustomFile;
   }
 }
-```
 
-<!-- TODO - автору: не хватает описания кода - на что обратить внимание, или что тут сделали -->
-
-Такой код не удастся скомпилировать. При этом остается доступ к статическим свойствам и методам родительского класса:
-
-```typescript
 const file = new ImageCustomFile();
-console.log(ImageCustomFile.maxCustomFileSize); // 1000
+
+console.log(ImageCustomFile.maxCustomFileSize); // 2000
 console.log(ImageCustomFile.isCustomFile(file)); // true
 ```
 
-<!-- TODO - автору: не хватает описания кода - на что обратить внимание, или что тут сделали -->
+Здесь `ImageCustomFile` объявил свои `maxCustomFileSize` и `isCustomFile`, и обращение по имени подкласса даёт именно их.
+
+TypeScript добавляет к этому одно требование: тип переопределённого свойства или метода должен остаться совместимым с родительским. Если вместо числа подставить строку, код не скомпилируется:
+
+```typescript
+class TextCustomFile extends CustomFile {
+  static maxCustomFileSize = 'unlimited'; // Error!
+}
+```
+
+Компилятор скажет `Class static side 'typeof TextCustomFile' incorrectly extends base class static side 'typeof CustomFile'`: статическая часть подкласса перестала подходить под статическую часть родителя.
+
+Подкласс, который ничего не переопределяет, пользуется статическими свойствами и методами родителя:
+
+```typescript
+class VideoCustomFile extends CustomFile {}
+
+console.log(VideoCustomFile.maxCustomFileSize); // 1000
+```


### PR DESCRIPTION
Closes #359

## Что было не так

Урок утверждал: «В отличие от JavaScript в TypeScript статические свойства и методы не могут быть переопределены в подклассах», и приводил пример с двумя пометками `// Error!`.

Утверждение неверное. Пример из урока компилируется без единой ошибки:

```console
$ tsc --noEmit --strict --target esnext --module esnext --moduleResolution bundler static-check.ts
TSC_EXIT=0
```

(typescript 6.0.3, тот же, что стоит в курсе.)

Заодно врал и следующий за ним фрагмент: `console.log(ImageCustomFile.maxCustomFileSize)` там подписан `// 1000`, хотя подкласс объявил `2000`, и в рантайме печатается именно `2000`. То есть студент, который проверит код руками, получит расхождение и с компилятором, и с выводом.

## Что стало

Статические члены наследуются и переопределяются — так же, как в JavaScript. Настоящее ограничение TypeScript другое и одно: тип переопределённого члена должен остаться совместимым с родительским, иначе `TS2417`:

```console
$ tsc --noEmit --strict … static-new-bad.ts
static-new-bad.ts(5,7): error TS2417: Class static side 'typeof TextCustomFile' incorrectly extends base class static side 'typeof CustomFile'.
  Types of property 'maxCustomFileSize' are incompatible.
    Type 'string' is not assignable to type 'number'.
```

Раздел переписан вокруг этого: сначала переопределение работает, потом ограничение по совместимости типов, потом подкласс, который ничего не переопределяет и пользуется родительскими членами.

Модификатор `override`, о котором спрашивает автор issue, в текст не вводится: он в курсе нигде не встречается, а для переопределения статики не требуется — `tsc` принимает код и без него. Требовать его начинает только `noImplicitOverride`, которого в `tsconfig.json` курса нет.

## Проверка

Все три новых фрагмента прогнаны компилятором и запущены; вывод совпадает с комментариями в коде:

| фрагмент | результат |
| --- | --- |
| переопределение статики | компилируется, печатает `2000`, `true`, `1000` |
| несовместимый тип (`'unlimited'` вместо числа) | `TS2417` |
| подкласс без переопределения | компилируется |

`make description-lint` и `make schema-validate` зелёные.

Правки только в теории, задание и решение урока не тронуты.
